### PR TITLE
enhancement: Alerts on login an register now throws a wait label information to the client when the server responds

### DIFF
--- a/client/src/components/LoginDisplayer.jsx
+++ b/client/src/components/LoginDisplayer.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
 import { useState } from 'react';
 import { Button, TextField, Alert, Snackbar, Box } from '@mui/material/';
 import { Link } from 'react-router-dom';
@@ -8,6 +9,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 
 export default function LoginDisplayer({ handleInputChange, formData, sendForm, userInfo, open, preHandleClose, loginData }) {
     const [showPassword, setShowPassword] = useState(false);
+    const [gatheredLoginData, setGatheredLoginData] = useState('');
     const isDesktop = useMediaQuery('(min-width: 900px)');
     const isTablet = useMediaQuery('(min-width: 426px) and (max-width: 899px)');
     const isMobile = useMediaQuery('(max-width: 425px)');
@@ -31,6 +33,10 @@ export default function LoginDisplayer({ handleInputChange, formData, sendForm, 
         width: '100vw',
         backgroundColor: 'black',
     }
+
+    useEffect(() => {
+        loginData ? setGatheredLoginData(loginData) : setGatheredLoginData('Por favor, Espere...');
+    }, [loginData])
 
     return (
         <>
@@ -96,9 +102,9 @@ export default function LoginDisplayer({ handleInputChange, formData, sendForm, 
 
                 </Box>
                 {/* <Box className="login-message">{loginData}</Box> */}
-                <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'center' }} open={open} autoHideDuration={5000} onClose={preHandleClose}>
+                <Snackbar anchorOrigin={{ vertical: 'top', horizontal: 'center' }} open={open} autoHideDuration={!loginData ? 999999 : 5000} onClose={preHandleClose}>
                     <Alert onClose={preHandleClose} severity="info" sx={{ width: '100%' }}>
-                        {loginData}
+                        {gatheredLoginData}
                     </Alert>
                 </Snackbar>
             </Box>

--- a/client/src/routes/Register.jsx
+++ b/client/src/routes/Register.jsx
@@ -7,6 +7,7 @@ import { useMediaQuery } from '@mui/material';
 import '../assets/styles.css';
 import '../assets/index.css';
 import { Helmet } from "react-helmet";
+import { useEffect, useState } from 'react';
 
 const Register = () => {
     const isDesktop = useMediaQuery('(min-width: 900px)');
@@ -21,6 +22,7 @@ const Register = () => {
         password: '',
         pwdConfirmation: '',
     })
+    const [gatheredState, setGatheredState] = useState('');
 
     if (registryCompletion) {
         setTimeout(() => {
@@ -32,11 +34,15 @@ const Register = () => {
         handleClose(event, reason);
     }
 
+    useEffect(() => {
+        state ? setGatheredState(state) : setGatheredState('Por favor, Espere...');
+    }, [state])
+
     return (
         <>
-        <Helmet>
-            <title>Register - Node Network</title>
-        </Helmet>
+            <Helmet>
+                <title>Register - Node Network</title>
+            </Helmet>
             <div className='register-background'>
                 <div className={isDesktop ? 'register-container' : isTablet ? 'register-container-tablet' : 'register-container-mobile'}>
                     <h1 className="register-title">Registro Nuevo</h1>
@@ -134,9 +140,9 @@ const Register = () => {
                         </Button>
                     </form>
                     {/* { state } */}
-                    <Snackbar sx={{ width: '100%', ml: 'auto', mr: 'auto', mt: '-13vh' }} anchorOrigin={{ vertical: 'top', horizontal: 'center' }} open={open} autoHideDuration={5000} onClose={preHandleClose}>
+                    <Snackbar sx={{ width: '100%', ml: 'auto', mr: 'auto', mt: '-13vh' }} anchorOrigin={{ vertical: 'top', horizontal: 'center' }} open={open} autoHideDuration={!state ? 999999 : 5000} onClose={preHandleClose}>
                         <Alert onClose={preHandleClose} severity="info" sx={{ width: '100%' }}>
-                            {state}
+                            {gatheredState}
                         </Alert>
                     </Snackbar>
                     <p className='mt-5 mb-5'>Ya tienes una cuenta? <Link id="register" to='/'> Inicia sesión </Link></p>


### PR DESCRIPTION
The way this project is made and the free tier backend limitations makes the client to wait for a server response, so in order to wait for a certain response... a label information now shows upon the request has started, then when the response arrives to the client the information label hides itself to show the response.